### PR TITLE
Updated the packages to use the latest versions of tools.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "modules/wit-bindgen"]
 	path = modules/wit-bindgen
-	url = https://github.com/jsturtevant/wit-bindgen.git
+	url = https://github.com/bytecodealliance/wit-bindgen.git
 [submodule "modules/wasm-tools"]
 	path = modules/wasm-tools
-	url = https://github.com/dicej/wasm-tools.git
+	url = https://github.com/bytecodealliance/wasm-tools.git

--- a/samples/calculator/Adder/OperationsImpl.cs
+++ b/samples/calculator/Adder/OperationsImpl.cs
@@ -1,6 +1,6 @@
-﻿namespace wit_computer.Wit.exports.example.calculator.Operations;
+﻿namespace ComputerWorld.wit.exports.example.calculator;
 
-public class OperationsImpl : Operations
+public class OperationsImpl : IOperations
 {
     public static int Add(int left, int right)
     {

--- a/samples/calculator/CalculatorComposed/CalculatorComposed.csproj
+++ b/samples/calculator/CalculatorComposed/CalculatorComposed.csproj
@@ -17,8 +17,8 @@
 
     <Target Name="ComposeWasmComponent" AfterTargets="Build">
         <PropertyGroup>
-            <EntrypointComponent>../CalculatorHost/bin/$(Configuration)/$(TargetFramework)/wasi-wasm/native/CalculatorHost.component.wasm</EntrypointComponent>
-            <DependencyComponent>../Adder/bin/$(Configuration)/$(TargetFramework)/wasi-wasm/native/Adder.component.wasm</DependencyComponent>
+            <EntrypointComponent>../CalculatorHost/bin/$(Configuration)/$(TargetFramework)/wasi-wasm/native/calculatorhost-component.wasm</EntrypointComponent>
+            <DependencyComponent>../Adder/bin/$(Configuration)/$(TargetFramework)/wasi-wasm/native/adder-component.wasm</DependencyComponent>
         </PropertyGroup>
         
         <MakeDir Directories="dist" />

--- a/samples/calculator/CalculatorHost/Program.cs
+++ b/samples/calculator/CalculatorHost/Program.cs
@@ -1,4 +1,4 @@
-﻿using wit_hostapp.Wit.imports.example.calculator.Operations;
+﻿using HostappWorld.wit.imports.example.calculator;
 
 var left = 123;
 var right = 456;

--- a/src/WasmComponent.Sdk/WasmComponent.Sdk.csproj
+++ b/src/WasmComponent.Sdk/WasmComponent.Sdk.csproj
@@ -10,9 +10,9 @@
         <!-- Things you might want to edit -->
         <!-- Set BuildWasmToolsLocally to true if you want to build modules/wasm-tools locally and use its output -->
         <BuildWasmToolsLocally>true</BuildWasmToolsLocally>
-        <PrebuiltWasmToolsVersion>1.0.51</PrebuiltWasmToolsVersion>
+        <PrebuiltWasmToolsVersion>1.202.0</PrebuiltWasmToolsVersion>
         <PrebuiltWasmToolsBaseUrl>https://github.com/bytecodealliance/wasm-tools/releases/download/wasm-tools-$(PrebuiltWasmToolsVersion)/wasm-tools-$(PrebuiltWasmToolsVersion)</PrebuiltWasmToolsBaseUrl>
-        <WasmtimeVersionForWasiSnapshotPreview1Adapters>14.0.4</WasmtimeVersionForWasiSnapshotPreview1Adapters>
+        <WasmtimeVersionForWasiSnapshotPreview1Adapters>19.0.1</WasmtimeVersionForWasiSnapshotPreview1Adapters>
 
         <WasmToolsModuleRoot>$(MSBuildThisFileDirectory)..\..\modules\wasm-tools\</WasmToolsModuleRoot>
 

--- a/src/WasmComponent.Sdk/build/WasmComponent.Sdk.targets
+++ b/src/WasmComponent.Sdk/build/WasmComponent.Sdk.targets
@@ -38,7 +38,7 @@
 
     <Target Name="PrepareWasmSdks" BeforeTargets="CheckWasmSdks" DependsOnTargets="ObtainWasiSdk; ObtainEmscripten">
         <PropertyGroup>
-            <EmSdk Condition="'$(EmSdk)' == ''">$(EmscriptenRoot)</EmSdk>
+            <EmSdk>$(EmscriptenRoot)</EmSdk>
             <WASI_SDK_PATH>$(WasiSdkRoot)</WASI_SDK_PATH>
         </PropertyGroup>
     </Target>

--- a/src/WasmComponent.Sdk/build/WasmComponent.Sdk.targets
+++ b/src/WasmComponent.Sdk/build/WasmComponent.Sdk.targets
@@ -6,13 +6,13 @@
 
     <PropertyGroup>
         <!-- Keep this block all in sync manually, since URLs can be arbitrary -->
-        <WasiSdkVersion>20.0</WasiSdkVersion>
-        <WasiSdkUrl Condition="$([MSBuild]::IsOSPlatform('Windows'))">https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-20/wasi-sdk-20.0.m-mingw.tar.gz</WasiSdkUrl>
-        <WasiSdkUrl Condition="$([MSBuild]::IsOSPlatform('Linux'))">https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-20/wasi-sdk-20.0-linux.tar.gz</WasiSdkUrl>
-        <WasiSdkUrl Condition="$([MSBuild]::IsOSPlatform('OSX'))">https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-20/wasi-sdk-20.0-macos.tar.gz</WasiSdkUrl>
+        <WasiSdkVersion>21.0</WasiSdkVersion>
+        <WasiSdkUrl Condition="$([MSBuild]::IsOSPlatform('Windows'))">https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-21/wasi-sdk-21.0.m-mingw.tar.gz</WasiSdkUrl>
+        <WasiSdkUrl Condition="$([MSBuild]::IsOSPlatform('Linux'))">https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-21/wasi-sdk-21.0-linux.tar.gz</WasiSdkUrl>
+        <WasiSdkUrl Condition="$([MSBuild]::IsOSPlatform('OSX'))">https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-21/wasi-sdk-21.0-macos.tar.gz</WasiSdkUrl>
         <WasiSdkRoot>$([System.IO.Path]::Combine("$([System.Environment]::GetFolderPath(SpecialFolder.UserProfile))", ".wasi-sdk", "wasi-sdk-$(WasiSdkVersion)"))</WasiSdkRoot>
 
-        <EmSdkVersion>3.1.23</EmSdkVersion>
+        <EmSdkVersion>3.1.55</EmSdkVersion>
         <EmSdkUrl>https://github.com/emscripten-core/emsdk/archive/refs/tags/$(EmSdkVersion).zip</EmSdkUrl>
         <EmscriptenRoot>$([System.IO.Path]::Combine("$([System.Environment]::GetFolderPath(SpecialFolder.UserProfile))", ".emsdk", "emsdk-$(EmSdkVersion)"))</EmscriptenRoot>
     </PropertyGroup>
@@ -31,13 +31,14 @@
             <WasiPreview1AdapterType>reactor</WasiPreview1AdapterType>
             <WasiPreview1AdapterType Condition="'$(OutputType.ToLower())' == 'exe'">command</WasiPreview1AdapterType>
             <WasiPreview1AdapterPath>$(MSBuildThisFileDirectory)../tools/wasi-wasm/wasi_snapshot_preview1.$(WasiPreview1AdapterType).wasm</WasiPreview1AdapterPath>
-            <NativeComponentBinary>$(NativeOutputPath)$(TargetName).component.wasm</NativeComponentBinary>
+            <!-- NativeComponentBinary should have a filename in kebab-case -->  
+            <NativeComponentBinary>$(NativeOutputPath)$(TargetName.ToLower().Replace(" ", "-"))-component.wasm</NativeComponentBinary>
         </PropertyGroup>
     </Target>
 
     <Target Name="PrepareWasmSdks" BeforeTargets="CheckWasmSdks" DependsOnTargets="ObtainWasiSdk; ObtainEmscripten">
         <PropertyGroup>
-            <EmSdk>$(EmscriptenRoot)</EmSdk>
+            <EmSdk Condition="'$(EmSdk)' == ''">$(EmscriptenRoot)</EmSdk>
             <WASI_SDK_PATH>$(WasiSdkRoot)</WASI_SDK_PATH>
         </PropertyGroup>
     </Target>

--- a/src/WitBindgen/WitBindgen.csproj
+++ b/src/WitBindgen/WitBindgen.csproj
@@ -10,7 +10,7 @@
         <!-- Things you might want to edit -->
         <!-- Set BuildWitBindgenLocally to true if you want to build modules/wit-bindgen locally and use its output -->
         <BuildWitBindgenLocally>true</BuildWitBindgenLocally>
-        <PrebuiltWitBindgenVersion>0.14.0</PrebuiltWitBindgenVersion>
+        <PrebuiltWitBindgenVersion>0.20.0</PrebuiltWitBindgenVersion>
         <PrebuiltWitBindgenBaseUrl>https://github.com/bytecodealliance/wit-bindgen/releases/download/wit-bindgen-cli-$(PrebuiltWitBindgenVersion)/wit-bindgen-v$(PrebuiltWitBindgenVersion)</PrebuiltWitBindgenBaseUrl>
 
         <WitBindgenModuleRoot>$(MSBuildThisFileDirectory)..\..\modules\wit-bindgen\</WitBindgenModuleRoot>

--- a/src/WitBindgen/build/WitBindgen.targets
+++ b/src/WitBindgen/build/WitBindgen.targets
@@ -1,10 +1,17 @@
 ﻿<Project>
     <Target Name="WitCompile_BeforeCsCompile" BeforeTargets="BeforeCompile"
 			Condition="'$(Language)' == 'C#' AND '@(Wit)' != ''"
-            DependsOnTargets="WitCompile_GetDependencies; WitCompile_InvokeTool">
+            DependsOnTargets="WitCompile_GetDependencies; CompileCabiRealloc; WitCompile_InvokeTool">
         <ItemGroup>
             <Compile Include="$(WitGeneratedFilesRoot)**\*.cs" />
             <NativeObjects Include="$(WitGeneratedFilesRoot)**\*.o" />
+        </ItemGroup>
+    </Target>
+
+    <Target Name="CompileCabiRealloc" BeforeTargets="IlcCompile" DependsOnTargets="WitCompile_InvokeTool" Inputs="$(WitGeneratedCabiReallocSourceFile)" Outputs="$(WitGeneratedFilesRoot)cabi_realloc.o" Condition="Exists($(WitGeneratedCabiReallocSourceFile))">
+        <Exec Command="emcc.bat &quot;$(WitGeneratedCabiReallocSourceFile)&quot; -c -o &quot;$(WitGeneratedFilesRoot)cabi_realloc.o&quot;"/>
+        <ItemGroup>
+            <NativeObjects Include="$(WitGeneratedFilesRoot)cabi_realloc.o" />
         </ItemGroup>
     </Target>
 
@@ -17,7 +24,7 @@
         </ItemGroup>
     </Target>
 
-    <Target Name="WitCompile_InvokeTool" Inputs="@(Wit);$(MSBuildProjectFile)" Outputs="@(WitGeneratedCsFiles);$(WitGeneratedFilesRoot)lastbuild.txt">
+    <Target Name="WitCompile_InvokeTool" Inputs="@(Wit);$(MSBuildProjectFile)" Outputs="@(WitGeneratedCsFiles);$(WitGeneratedCabiReallocSourceFiles);@(NativeObjects);$(WitGeneratedFilesRoot)lastbuild.txt">
         <ItemGroup>
             <WitGeneratedCsFiles Remove="@(WitGeneratedCsFiles)" />
             <Wit Update="@(Wit)">
@@ -29,9 +36,18 @@
         
         <RemoveDir Directories="$(WitGeneratedFilesRoot)" />
         <MakeDir Directories="$(WitGeneratedFilesRoot)" />
-        <Exec Command="$(WitBindgenExe) c-sharp %(Wit.Identity) %(Wit.WitWorldArg) --out-dir $(WitGeneratedFilesRoot)" />
+        <Exec Command="$(WitBindgenExe) c-sharp --runtime native-aot %(Wit.Identity) %(Wit.WitWorldArg) --out-dir $(WitGeneratedFilesRoot)" />
         <WriteLinesToFile File="$(WitGeneratedFilesRoot)lastbuild.txt" Lines="" Overwrite="true" />
-        
+
+
+        <ItemGroup>
+            <WitGeneratedCabiReallocSourceFiles Include="$(WitGeneratedFilesRoot)**\*_cabi_realloc.c"/>
+        </ItemGroup>
+        <PropertyGroup>
+            <!-- Even when there are multiple worlds included in a single library, only a single cabi_realloc method should be included -->
+            <WitGeneratedCabiReallocSourceFile>%(WitGeneratedCabiReallocSourceFiles.Identity)</WitGeneratedCabiReallocSourceFile>
+        </PropertyGroup>
+
         <ItemGroup>
             <WitGeneratedCsFiles Include="$(WitGeneratedFilesRoot)**\*.cs" />
 			<FileWrites Include="$(WitGeneratedFilesRoot)lastbuild.txt" />

--- a/test/E2ETest/testapps/E2EConsumer/E2EConsumer.csproj
+++ b/test/E2ETest/testapps/E2EConsumer/E2EConsumer.csproj
@@ -33,11 +33,11 @@
     <!-- After build, create the composed component so it can be executed in the test -->
     <Target Name="ComposeWasmComponent" AfterTargets="ConvertToWasmComponent">
         <PropertyGroup>
-            <DependencyComponent>../E2EProducer/bin/$(Configuration)/$(TargetFramework)/wasi-wasm/native/E2EProducer.component.wasm</DependencyComponent>
+            <DependencyComponent>../E2EProducer/bin/$(Configuration)/$(TargetFramework)/wasi-wasm/native/e2eproducer-component.wasm</DependencyComponent>
         </PropertyGroup>
 
         <MakeDir Directories="dist" />
-        <Exec Command="$(WasmToolsExe) compose -o dist/composed.wasm bin/$(Configuration)/$(TargetFramework)/wasi-wasm/native/E2EConsumer.component.wasm -d $(DependencyComponent)" />
+        <Exec Command="$(WasmToolsExe) compose -o dist/composed.wasm bin/$(Configuration)/$(TargetFramework)/wasi-wasm/native/e2econsumer-component.wasm -d $(DependencyComponent)" />
     </Target>
 
 </Project>

--- a/test/E2ETest/testapps/E2EConsumer/Program.cs
+++ b/test/E2ETest/testapps/E2EConsumer/Program.cs
@@ -1,5 +1,5 @@
 ﻿using System.Runtime.InteropServices;
-using wit_consumer.Wit.imports.test.producerConsumer.Operations;
+using ConsumerWorld.wit.imports.test.producerConsumer;
 
 Console.WriteLine($"Hello, world on {RuntimeInformation.OSArchitecture}");
 

--- a/test/E2ETest/testapps/E2EProducer/OperationsImpl.cs
+++ b/test/E2ETest/testapps/E2EProducer/OperationsImpl.cs
@@ -1,6 +1,6 @@
-﻿namespace wit_producer.Wit.exports.test.producerConsumer.Operations;
+﻿namespace ProducerWorld.wit.exports.test.producerConsumer;
 
-public class OperationsImpl : Operations
+public class OperationsImpl : IOperations
 {
     public static int Add(int left, int right)
     {

--- a/test/WasmComponentSdkTest/WasmComponentSdkTest/SimpleProducerConsumerTest.cs
+++ b/test/WasmComponentSdkTest/WasmComponentSdkTest/SimpleProducerConsumerTest.cs
@@ -19,14 +19,14 @@ public class SimpleProducerConsumerTest
     [Fact]
     public void CanBuildComponentWithImport()
     {
-        var witInfo = GetWitInfo(FindModulePath($"../testapps/SimpleConsumer/bin/{Config}", "SimpleConsumer.component.wasm"));
+        var witInfo = GetWitInfo(FindModulePath($"../testapps/SimpleConsumer/bin/{Config}", "simpleconsumer-component.wasm"));
         Assert.Contains("import test:producer-consumer/operations", witInfo);
     }
 
     [Fact]
     public void CanBuildComponentWithExport()
     {
-        var witInfo = GetWitInfo(FindModulePath($"../testapps/SimpleProducer/bin/{Config}", "SimpleProducer.component.wasm"));
+        var witInfo = GetWitInfo(FindModulePath($"../testapps/SimpleProducer/bin/{Config}", "simpleproducer-component.wasm"));
         Assert.Contains("export test:producer-consumer/operations", witInfo);
     }
 

--- a/test/WasmComponentSdkTest/testapps/SimpleConsumer/Program.cs
+++ b/test/WasmComponentSdkTest/testapps/SimpleConsumer/Program.cs
@@ -1,5 +1,5 @@
 ﻿using System.Runtime.InteropServices;
-using wit_consumer.Wit.imports.test.producerConsumer.Operations;
+using ConsumerWorld.wit.imports.test.producerConsumer;
 
 Console.WriteLine($"Hello, world on {RuntimeInformation.OSArchitecture}");
 

--- a/test/WasmComponentSdkTest/testapps/SimpleConsumer/SimpleConsumer.csproj
+++ b/test/WasmComponentSdkTest/testapps/SimpleConsumer/SimpleConsumer.csproj
@@ -31,7 +31,7 @@
     <!-- After build, create the composed component so it can be executed in the test -->
     <Target Name="ComposeWasmComponent" AfterTargets="ConvertToWasmComponent">
         <PropertyGroup>
-            <DependencyComponent>../SimpleProducer/bin/$(Configuration)/$(TargetFramework)/wasi-wasm/native/SimpleProducer.component.wasm</DependencyComponent>
+            <DependencyComponent>../SimpleProducer/bin/$(Configuration)/$(TargetFramework)/wasi-wasm/native/simpleproducer-component.wasm</DependencyComponent>
         </PropertyGroup>
 
         <MakeDir Directories="dist" />

--- a/test/WasmComponentSdkTest/testapps/SimpleProducer/OperationsImpl.cs
+++ b/test/WasmComponentSdkTest/testapps/SimpleProducer/OperationsImpl.cs
@@ -1,6 +1,6 @@
-﻿namespace wit_producer.Wit.exports.test.producerConsumer.Operations;
+﻿namespace ProducerWorld.wit.exports.test.producerConsumer;
 
-public class OperationsImpl : Operations
+public class OperationsImpl : IOperations
 {
     public static int Add(int left, int right)
     {

--- a/test/WitBindgenTest/WitBindgenTest/CodeGenerationTest.cs
+++ b/test/WitBindgenTest/WitBindgenTest/CodeGenerationTest.cs
@@ -1,5 +1,5 @@
-using wit_my_funcs;
-using wit_producer;
+using MyFuncsWorld.exports;
+using ProducerWorld;
 using Xunit;
 
 namespace WitBindgenTest;
@@ -14,7 +14,7 @@ public class CodeGenerationTest
             LibraryUsingWit.Code.CallSimpleDoSomething());
 
         // Currently, it generates [DllImport("*", ...)] so validate that
-        Assert.StartsWith("Unable to load DLL '*'", ex.Message);
+        Assert.StartsWith("Unable to load DLL 'do-something'", ex.Message);
     }
 
     [Fact]

--- a/test/WitBindgenTest/testapps/LibraryUsingWit/Code.cs
+++ b/test/WitBindgenTest/testapps/LibraryUsingWit/Code.cs
@@ -4,6 +4,6 @@ public class Code
 {
     public static void CallSimpleDoSomething()
     {
-        wit_my_funcs.exports.MyFuncsWorld.DoSomething();
+        MyFuncsWorld.exports.MyFuncsWorld.DoSomething();
     }
 }

--- a/test/WitBindgenTest/testapps/LibraryUsingWit/MyFuncsWorldImpl.cs
+++ b/test/WitBindgenTest/testapps/LibraryUsingWit/MyFuncsWorldImpl.cs
@@ -1,6 +1,6 @@
-﻿namespace wit_my_funcs;
+﻿namespace MyFuncsWorld.exports;
 
-public class MyFuncsWorldImpl : MyFuncsWorld
+public class MyFuncsWorldImpl : IMyFuncsWorld
 {
     public static int GetNumber()
     {

--- a/test/WitBindgenTest/testapps/LibraryUsingWit/SomeStuffImpl.cs
+++ b/test/WitBindgenTest/testapps/LibraryUsingWit/SomeStuffImpl.cs
@@ -1,10 +1,10 @@
 ﻿// I don't think this namespace should be so different to the one in MyFuncsWorldImpl,
 // but currently that's what the codegen requires
-using wit_producer.Wit.exports.test.multipleWorlds.SomeStuff;
+using ProducerWorld.wit.exports.test.multipleWorlds;
 
-namespace wit_producer;
+namespace ProducerWorld;
 
-public class SomeStuffImpl : SomeStuff
+public class SomeStuffImpl : ISomeStuff
 {
     public static int GetNumber()
     {


### PR DESCRIPTION
updated:
- wasi sdk
- emsdk
- wit-bindgen

wit-bindgen produces completely different C# code compared to 0.14.0, so the targets were updated to produce valid wasm component